### PR TITLE
Specify the namespace in the deploy yaml

### DIFF
--- a/deploy/00-permissions-metrics-server-exporter.yaml
+++ b/deploy/00-permissions-metrics-server-exporter.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: metrics-server-exporter
+  namespace: kube-system
   labels:
     k8s-app: metrics-server-exporter
 rules:
@@ -14,6 +15,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: metrics-server-exporter
+  namespace: kube-system
   labels:
     k8s-app: metrics-server-exporter
 ---
@@ -21,6 +23,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: metrics-server-exporter
+  namespace: kube-system
 subjects:
 - kind: ServiceAccount
   namespace: kube-system

--- a/deploy/10-deployment-metrics-server-exporter.yaml
+++ b/deploy/10-deployment-metrics-server-exporter.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: metrics-server-exporter
+  namespace: kube-system
   labels:
     k8s-app: metrics-server-exporter
 spec:

--- a/deploy/20-service-metrics-server-exporter.yaml
+++ b/deploy/20-service-metrics-server-exporter.yaml
@@ -6,6 +6,7 @@ metadata:
     prometheus.io/port: "8000"
     prometheus.io/scrape: "true"
   name: metrics-server-exporter
+  namespace: kube-system
   labels:
     k8s-app: metrics-server-exporter
 spec:


### PR DESCRIPTION
Addresses issues like https://github.com/grupozap/metrics-server-exporter/issues/45 where people deploy from the example yaml files but don't specify the namespace then the exporter won't show any data. This PR provides the correct namespace for a working exporter in the exmample deploy files.